### PR TITLE
feat(callback.go): add functionality to edit incident summary via modal

### DIFF
--- a/presentation/blocks/edit_incident_summary.go
+++ b/presentation/blocks/edit_incident_summary.go
@@ -1,0 +1,31 @@
+package blocks
+
+import (
+	"github.com/slack-go/slack"
+)
+
+func EditIncidentSummary(currentSummary string) slack.Blocks {
+	return slack.Blocks{
+		BlockSet: []slack.Block{
+			// 事象内容
+			&slack.InputBlock{
+				Type:    slack.MBTInput,
+				BlockID: "edit_summary_block",
+				Label: &slack.TextBlockObject{
+					Type: "plain_text",
+					Text: "事象内容を編集",
+				},
+				Element: &slack.PlainTextInputBlockElement{
+					Type:         slack.METPlainTextInput,
+					ActionID:     "summary_text",
+					InitialValue: currentSummary,
+					Multiline:    true,
+					Placeholder: slack.NewTextBlockObject(
+						"plain_text", "例: ユーザーがログインできない", false, false,
+					),
+				},
+				Optional: false,
+			},
+		},
+	}
+}

--- a/presentation/blocks/inchannel_options.go
+++ b/presentation/blocks/inchannel_options.go
@@ -20,6 +20,11 @@ func InChannelOptions() []*slack.OptionBlockObject {
 			nil,
 		),
 		slack.NewOptionBlockObject(
+			"edit_incident_summary",
+			slack.NewTextBlockObject("plain_text", "📝 事象内容を編集する", false, false),
+			nil,
+		),
+		slack.NewOptionBlockObject(
 			"create_postmortem",
 			slack.NewTextBlockObject("plain_text", "📝 ポストモーテムを作成する", false, false),
 			nil,


### PR DESCRIPTION
Introduce a new case "edit_incident_summary" to handle editing incident summaries. Implement `openEditSummaryModal` to open a modal for editing and `submitEditSummaryModal` to handle submission. Update channel topic and notify changes.

test(handler_test.go): add tests for edit incident summary feature

Add test cases to ensure the new "edit_incident_summary" and "edit_summary_modal" functionalities work as expected.

feat(blocks): add edit incident summary block

Create a new block for editing incident summaries, allowing users to input and update the incident description. Add this option to the in-channel options.