### PR TITLE
機能(handler): 未クローズインシデント一覧表示機能を追加

### DIFF
--- a/domain/repository/ai_repository.go
+++ b/domain/repository/ai_repository.go
@@ -27,6 +27,7 @@ type AIRepositorier interface {
 	GenerateActionItems(description, slackMessages string) (string, error)
 	GenerateLessonsLearned(description, slackMessages string) (string, string, string, error) // うまくいったこと、うまくいかなかったこと、幸運だったこと
 	FormatTimeline(rawTimeline string) (string, error)
+	AnalyzeRemainingTasks(description, slackMessages string) (string, error)
 }
 
 type AIRepository struct {
@@ -642,6 +643,34 @@ func (h *AIRepository) FormatTimeline(rawTimeline string) (string, error) {
 
 ## 生のタイムライン
 %s`, rawTimeline)
+
+	return h.callOpenAIWithRetry(prompt)
+}
+
+// 残件分析
+func (h *AIRepository) AnalyzeRemainingTasks(description, slackMessages string) (string, error) {
+	prompt := fmt.Sprintf(`## 依頼内容
+インシデント対応の残件を分析してください。
+あなたには人間が考えた事象の概要と、Slackのメッセージが与えられます。
+
+## フォーマットの指定：
+200文字以内で、以下の観点から残件を記載してください：
+- まだ完了していない対応内容
+- 今後実施が必要な作業
+- 監視や確認が必要な項目
+- 対応待ちの課題
+
+**重要**: Slackメッセージから明確に残件が読み取れる場合のみ記載してください。
+情報が不十分な場合は「メッセージから残件を確認できませんでした」と返却してください。
+推測や仮定に基づく内容は含めないでください。
+
+あなたから受け取った文章はそのまま表示されるので、構造化文字列ではなく、残件の内容だけを返却してください。
+
+## 人間が考えた事象の概要
+%s
+
+## 関連するSlackのメッセージ
+%s`, description, slackMessages)
 
 	return h.callOpenAIWithRetry(prompt)
 }

--- a/handler/callback_test.go
+++ b/handler/callback_test.go
@@ -70,6 +70,10 @@ func (m *mockAIRepository) FormatTimeline(rawTimeline string) (string, error) {
 	return "", nil
 }
 
+func (m *mockAIRepository) AnalyzeRemainingTasks(description, slackMessages string) (string, error) {
+	return "データベースの性能確認、監視アラートの閾値調整", nil
+}
+
 func TestSummarizeProgress(t *testing.T) {
 	t.Setenv("TEST_MODE", "true")
 

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -86,6 +86,9 @@ func Handle(ctx context.Context, configPath string) error {
 		cfgRepository,
 	)
 
+	// EventHandlerにCallbackHandlerを設定
+	eventHandler.SetCallbackHandler(callbackHandler)
+
 	// 1分ごとに各インシデントの15分間隔チェックを確認
 	ticker := time.NewTicker(1 * time.Minute)
 	defer ticker.Stop()

--- a/presentation/blocks/link_incident_options.go
+++ b/presentation/blocks/link_incident_options.go
@@ -6,6 +6,13 @@ import "github.com/slack-go/slack"
 func LinkIncidentOptions(isThread bool, isLinked bool) []*slack.OptionBlockObject {
 	var options []*slack.OptionBlockObject
 
+	// 未クローズインシデント一覧を最初に追加（常に表示）
+	options = append(options, slack.NewOptionBlockObject(
+		"list_open_incidents",
+		slack.NewTextBlockObject("plain_text", "📋 未クローズインシデント一覧", false, false),
+		nil,
+	))
+
 	if isLinked {
 		// 既に紐づけられている場合は解除オプションのみ表示
 		var unlinkText string


### PR DESCRIPTION
通常チャンネルでボットをメンションした際に、未クローズのインシデント一覧を表示する機能を追加。

主な変更:
- AIRepository: AnalyzeRemainingTasksメソッドを追加し、OpenAIで残件を自動分析
- CallbackHandler: listOpenIncidentsメソッドを追加し、各インシデントの詳細をスレッドに投稿
  - インシデント名、サービス名、ステータス、レベル、概要、残件、チャンネルリンクを含む
  - collectChannelMessagesを使用してインシデント開始以降の全メッセージ（スレッド含む）から残件を分析
- LinkIncidentOptions: 未クローズインシデント一覧オプションを追加
- EventHandler: 通常チャンネルメニューの表示ロジックを簡素化
- デバッグログを追加して動作確認を容易に

使い方:
通常チャンネルでボットをメンションし、表示されるメニューから「📋 未クローズインシデント一覧」を選択