### PR TITLE
設定ファイルで通知タイプ(none/here/channel)を選択可能に

### DIFF
--- a/domain/repository/config_repository.go
+++ b/domain/repository/config_repository.go
@@ -41,6 +41,7 @@ type Config struct {
 	ChannelPrefix              string                  `mapstructure:"channel_prefix"`
 	IncidentLevelList          []entity.IncidentLevel  `mapstructure:"incident_levels" validate:"required"`
 	DefaultConfluence          entity.ConfluenceConfig `mapstructure:"default_confluence"`
+	NotificationType           string                  `mapstructure:"notification_type" validate:"omitempty,oneof=none here channel"`
 }
 
 func (c *Config) Services(_ context.Context) ([]entity.Service, error) {
@@ -92,4 +93,13 @@ func (c *Config) IncidentLevelByLevel(_ context.Context, id int) (*entity.Incide
 
 func (c *Config) GetGlobalAnnouncementChannels(_ context.Context) []string {
 	return c.GlobalAnnouncementChannels
+}
+
+// GetNotificationType は設定された通知タイプを返す (none/here/channel)
+// 設定されていない場合は "here" をデフォルトとして返す
+func (c *Config) GetNotificationType() string {
+	if c.NotificationType == "" {
+		return "here"
+	}
+	return c.NotificationType
 }

--- a/handler/callback_test.go
+++ b/handler/callback_test.go
@@ -454,3 +454,51 @@ func TestIncidentSummaryUpdatedBlocks(t *testing.T) {
 		t.Error("Expected recovered title for recovered incident")
 	}
 }
+
+func TestGetNotificationType(t *testing.T) {
+	t.Setenv("TEST_MODE", "true")
+
+	tests := []struct {
+		name           string
+		config         *repository.Config
+		expectedResult string
+	}{
+		{
+			name: "notification_type が here の場合",
+			config: &repository.Config{
+				NotificationType: "here",
+			},
+			expectedResult: "here",
+		},
+		{
+			name: "notification_type が channel の場合",
+			config: &repository.Config{
+				NotificationType: "channel",
+			},
+			expectedResult: "channel",
+		},
+		{
+			name: "notification_type が none の場合",
+			config: &repository.Config{
+				NotificationType: "none",
+			},
+			expectedResult: "none",
+		},
+		{
+			name: "notification_type が未設定の場合はhereがデフォルト",
+			config: &repository.Config{
+				NotificationType: "",
+			},
+			expectedResult: "here",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.config.GetNotificationType()
+			if result != tt.expectedResult {
+				t.Errorf("Expected %s, got %s", tt.expectedResult, result)
+			}
+		})
+	}
+}

--- a/presentation/blocks/incident_level_changed.go
+++ b/presentation/blocks/incident_level_changed.go
@@ -6,10 +6,12 @@ import (
 	"github.com/slack-go/slack"
 )
 
-func IncidentLevelChanged(userID, incidentLevel string) []slack.Block {
+func IncidentLevelChanged(userID, incidentLevel, notificationType string) []slack.Block {
+	notificationText := AddNotification("インシデントレベルが変更されました", notificationType)
+
 	return []slack.Block{
 		slack.NewSectionBlock(
-			slack.NewTextBlockObject("mrkdwn", "<!here> インシデントレベルが変更されました", false, false),
+			slack.NewTextBlockObject("mrkdwn", notificationText, false, false),
 			nil,
 			nil,
 		),

--- a/presentation/blocks/incident_recovered.go
+++ b/presentation/blocks/incident_recovered.go
@@ -7,7 +7,9 @@ import (
 	"github.com/slack-go/slack"
 )
 
-func IncidentRecovered(userID, handlerID string) []slack.Block {
+func IncidentRecovered(userID, handlerID, notificationType string) []slack.Block {
+	notificationText := AddNotification("インシデントが復旧しました。", notificationType)
+
 	return []slack.Block{
 		slack.NewSectionBlock(
 			slack.NewTextBlockObject("mrkdwn", fmt.Sprintf("<@%s> さんがインシデントの復旧を宣言しました", userID), false, false),
@@ -15,7 +17,7 @@ func IncidentRecovered(userID, handlerID string) []slack.Block {
 			nil,
 		),
 		slack.NewSectionBlock(
-			slack.NewTextBlockObject("mrkdwn", "<!here> インシデントが復旧しました。", false, false),
+			slack.NewTextBlockObject("mrkdwn", notificationText, false, false),
 			nil,
 			nil,
 		),

--- a/presentation/blocks/incident_reopened.go
+++ b/presentation/blocks/incident_reopened.go
@@ -7,14 +7,16 @@ import (
 	"github.com/slack-go/slack"
 )
 
-func IncidentReopened(userID, handlerID string) []slack.Block {
+func IncidentReopened(userID, handlerID, notificationType string) []slack.Block {
+	notificationText := AddNotification("インシデントが再発し、対応を再開します。", notificationType)
+
 	blocks := []slack.Block{
 		slack.NewSectionBlock(
 			slack.NewTextBlockObject("mrkdwn", fmt.Sprintf("<@%s> さんがインシデントを再開しました", userID), false, false),
 			nil, nil,
 		),
 		slack.NewSectionBlock(
-			slack.NewTextBlockObject("mrkdwn", "<!here> インシデントが再発し、対応を再開します。", false, false),
+			slack.NewTextBlockObject("mrkdwn", notificationText, false, false),
 			nil, nil,
 		),
 	}

--- a/presentation/blocks/notification.go
+++ b/presentation/blocks/notification.go
@@ -1,0 +1,15 @@
+package blocks
+
+// AddNotification は通知タイプに応じてメッセージに通知を追加する
+func AddNotification(message, notificationType string) string {
+	switch notificationType {
+	case "here":
+		return "<!here> " + message
+	case "channel":
+		return "<!channel> " + message
+	case "none":
+		return message
+	default:
+		return message
+	}
+}


### PR DESCRIPTION
## 概要
現状@hereで通知している箇所を、設定ファイルで`none`/`here`/`channel`から選択できるようにしました。

## 変更内容
- `Config`構造体に`notification_type`設定を追加
  - 設定可能な値: `none`, `here`, `channel`
  - デフォルト値: `here`（未設定時）
- 通知処理を共通化してDRY原則を適用
  - 新規ファイル: `presentation/blocks/notification.go`
  - `AddNotification()`共通関数を実装
- 以下の通知箇所で設定値に対応
  - `broadCastAnnouncement`: アナウンスチャンネルへの通知
  - `IncidentRecovered`: インシデント復旧通知
  - `IncidentReopened`: インシデント再開通知
  - `IncidentLevelChanged`: レベル変更通知

## 使い方
設定ファイルに以下を追加:
```yaml
notification_type: channel  # here, channel, none から選択
```

- `here`: `<!here>`でチャンネル内のアクティブユーザーに通知
- `channel`: `<!channel>`でチャンネルの全メンバーに通知
- `none`: メンション通知なし
- 未設定: デフォルトで`here`として動作

## テスト
- `TestGetNotificationType`を追加し、すべてのケース(here/channel/none/未設定)をテスト
- 既存のテストもすべて通過
- linterもクリア