### PR TITLE
機能(postmortem): ポストモーテム作成をピン留め不要でチャンネル全履歴から自動生成

### DIFF
--- a/domain/repository/token_utils.go
+++ b/domain/repository/token_utils.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -11,11 +12,21 @@ import (
 )
 
 const (
-	// GPT-4のトークン制限 (8K モデルの場合、安全マージンを設けて80%を使用)
-	MaxTokensGPT4 = 6400
+	// デフォルトのトークン制限（大規模コンテキストモデル向け）
+	DefaultMaxTokens = 200000
 	// 1つのメッセージあたりの平均トークン数の見積もり
 	AverageTokensPerMessage = 30
 )
+
+// GetMaxTokens は環境変数またはデフォルト値からトークン制限を取得
+func GetMaxTokens() int {
+	if envMaxTokens := os.Getenv("MAX_TOKENS"); envMaxTokens != "" {
+		if maxTokens, err := strconv.Atoi(envMaxTokens); err == nil && maxTokens > 0 {
+			return maxTokens
+		}
+	}
+	return DefaultMaxTokens
+}
 
 // トークン計算ユーティリティ
 type TokenCalculator struct {

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -129,6 +129,10 @@ func (m *mockSlackRepo) GetChannelMessagesAfter(channelID, after string) ([]slac
 	return []slack.Message{}, nil
 }
 
+func (m *mockSlackRepo) GetAllChannelMessages(channelID string) ([]slack.Message, error) {
+	return []slack.Message{}, nil
+}
+
 func (m *mockSlackRepo) GetThreadReplies(channelID, threadTS string) ([]slack.Message, error) {
 	return []slack.Message{}, nil
 }


### PR DESCRIPTION
## Summary
- ポストモーテム作成時にピン留めメッセージではなく、チャンネル全履歴を自動取得するように変更
- 大量メッセージ時のコンテキスト溢れを防ぐため、トークン制限対策を実装
- トークン制限をデフォルト200Kに引き上げ（GPT-5 mini等の大規模コンテキストモデル対応）

## 主な変更点
- `GetAllChannelMessages`: チャンネル全メッセージをページング対応で取得（スレッド・メンション変換込み）
- `PrepareMessagesForPostMortem`: トークン制限を超える場合は自動的に要約・分割処理を実行
- `MAX_TOKENS` 環境変数でトークン制限をカスタマイズ可能

## Test plan
- [x] make lint 通過
- [x] go test ./... 通過
- [ ] 実際のSlackチャンネルでポストモーテム作成を確認