### PR TITLE
修正(postmortem): ボタンテキストからピン留め関連の記述を削除

### DIFF
--- a/presentation/blocks/postmortem_button.go
+++ b/presentation/blocks/postmortem_button.go
@@ -2,14 +2,14 @@ package blocks
 
 import "github.com/slack-go/slack"
 
-// ピンを打つことをアナウンスしてにポストモーテムを作成するボタンを表示する
+// ポストモーテムを作成するボタンを表示する
 func PostMortemButton() []slack.Block {
 	return []slack.Block{
 		slack.NewHeaderBlock(
 			slack.NewTextBlockObject("plain_text", "📝 ポストモーテムを作成しましょう！", false, false),
 		),
 		slack.NewSectionBlock(
-			slack.NewTextBlockObject("mrkdwn", "🚀 この事象に関するポストモーテムを作成しましょう。\nこのチャンネルの主要なメッセージにピンを打ってから作成ボタンを押下してください", false, false),
+			slack.NewTextBlockObject("mrkdwn", "🚀 この事象に関するポストモーテムを作成しましょう。\nチャンネルの履歴から自動生成します。作成ボタンを押下してください", false, false),
 			nil,
 			nil,
 		),
@@ -19,7 +19,7 @@ func PostMortemButton() []slack.Block {
 			slack.NewButtonBlockElement(
 				"postmortem_action",
 				"postmortem_button",
-				slack.NewTextBlockObject("plain_text", "📝 ピンを打ったのでポストモーテムを作成する", false, false),
+				slack.NewTextBlockObject("plain_text", "📝 ポストモーテムを作成する", false, false),
 			).WithStyle(slack.StylePrimary),
 		),
 	}


### PR DESCRIPTION
## Summary
- ポストモーテム作成がチャンネル全履歴から自動生成になったため、ピン留めに関するボタンテキスト・説明文を更新
- 「ピンを打ってから作成ボタンを押下してください」→「チャンネルの履歴から自動生成します。作成ボタンを押下してください」
- 「ピンを打ったのでポストモーテムを作成する」→「ポストモーテムを作成する」

## Test plan
- [ ] Slackでポストモーテムボタンが正しいテキストで表示されることを確認