### PR TITLE
機能(confluence): CONFLUENCE_DEBUG環境変数でデバッグログを制御

### DIFF
--- a/domain/repository/confluence_repository.go
+++ b/domain/repository/confluence_repository.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/microcosm-cc/bluemonday"
 	"github.com/pyama86/YAS3/domain/entity"
@@ -18,6 +19,8 @@ type ConfluenceRepository struct {
 }
 
 func NewConfluenceRepository(domain, user, password, spaceKey, ancestorID string) (*ConfluenceRepository, error) {
+	goconfluence.SetDebug(os.Getenv("CONFLUENCE_DEBUG") != "")
+
 	api, err := goconfluence.NewAPI(
 		fmt.Sprintf("https://%s.atlassian.net/wiki/rest/api", domain),
 		user,


### PR DESCRIPTION
## 変更内容

Confluenceページ作成時に `400 Bad Request` エラーが発生した際、実際のエラー原因が不明だったため、`goconfluence` ライブラリのデバッグ出力を環境変数で制御できるようにした。

## 背景

`virtomize/confluence-go-api` ライブラリは 400 レスポンスを受け取った際にレスポンスボディを捨てて `"unknown response status: 400 Bad Request"` のみ返す実装になっており、Confluenceからの実際のエラーメッセージが見えない状態だった。

## 変更点

- `NewConfluenceRepository` 初期化時に `CONFLUENCE_DEBUG` 環境変数が空でない場合、`goconfluence.SetDebug(true)` を呼び出すようにした

## 使い方

```sh
CONFLUENCE_DEBUG=1 ./yas3
```

有効にするとリクエスト・レスポンスの全内容がログに出力される。