### PR TITLE
修正(confluence): &lt;li&gt;内の&lt;br&gt;を除去してFabric Editor 400エラーを修正

### DIFF
--- a/domain/repository/confluence_repository.go
+++ b/domain/repository/confluence_repository.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 
 	"github.com/microcosm-cc/bluemonday"
 	"github.com/pyama86/YAS3/domain/entity"
 	"github.com/russross/blackfriday/v2"
 	goconfluence "github.com/virtomize/confluence-go-api"
 )
+
+// Confluence Fabric EditorのADFはlistItem内のhardBreakを非サポートのため除去する
+var brInListItem = regexp.MustCompile(`(?i)<br\s*/?>\s*</li>`)
 
 type ConfluenceRepository struct {
 	ansectorID string
@@ -38,11 +42,11 @@ func NewConfluenceRepository(domain, user, password, spaceKey, ancestorID string
 }
 
 func (c *ConfluenceRepository) ExportPostMortem(ctx context.Context, title, body string, service *entity.Service) (string, error) {
-	renderer := blackfriday.NewHTMLRenderer(blackfriday.HTMLRendererParameters{
-		Flags: blackfriday.HrefTargetBlank,
-	})
+	// HrefTargetBlankは使用しない（target属性はConfluence Storage Formatで非サポート）
+	renderer := blackfriday.NewHTMLRenderer(blackfriday.HTMLRendererParameters{})
 	output := blackfriday.Run([]byte(body), blackfriday.WithExtensions(blackfriday.HardLineBreak+blackfriday.Autolink), blackfriday.WithRenderer(renderer))
-	html := bluemonday.UGCPolicy().SanitizeBytes(output)
+	sanitized := bluemonday.UGCPolicy().SanitizeBytes(output)
+	html := brInListItem.ReplaceAllString(string(sanitized), "</li>")
 
 	// サービスのConfluence設定があれば使用し、なければデフォルト設定を使用
 	spaceKey := c.spaceKey


### PR DESCRIPTION
## 原因

Confluence Fabric Editor（新エディタ）は ADF（Atlassian Document Format）で動作しており、`listItem` 内の `hardBreak`（= `<br>`）を非サポート。

`blackfriday` の `HardLineBreak` 拡張が `<li>` 末尾に `<br>` を生成するため、以下のエラーが発生していた。

```
com.atlassian.confluence.api.service.exceptions.api.BadRequestException:
Content contains unsupported extensions and cannot be edited in Fabric editor
```

## 変更内容

- `<li>` 末尾の `<br>` を正規表現で除去（`<p>` 内の `<br>` は ADF の `hardBreak` に変換されるため残す）
- `target` 属性を生成する `HrefTargetBlank` フラグを削除（Confluence Storage Format 非サポート）