### PR TITLE
障害報告チャンネルへの手動通知機能を追加

### DIFF
--- a/doc/slack_app_manifest.yml
+++ b/doc/slack_app_manifest.yml
@@ -1,0 +1,32 @@
+display_information:
+  name: YAS3
+  description: Yet Another Slack Survival System - incident response bot
+  background_color: "#d40e0e"
+features:
+  bot_user:
+    display_name: YAS3
+    always_online: true
+oauth_config:
+  scopes:
+    bot:
+      - app_mentions:read
+      - channels:read
+      - channels:history
+      - channels:manage
+      - chat:write
+      - chat:write.public
+      - pins:read
+      - files:write
+      - usergroups:read
+      - users:read
+      - users:read.email
+settings:
+  event_subscriptions:
+    bot_events:
+      - app_mention
+      - channel_archive
+  interactivity:
+    is_enabled: true
+  org_deploy_enabled: false
+  socket_mode_enabled: true
+  token_rotation_enabled: false

--- a/domain/repository/ai_repository.go
+++ b/domain/repository/ai_repository.go
@@ -21,6 +21,7 @@ type AIRepositorier interface {
 	GenerateTitle(description, slackMessages string) (string, error)
 	GenerateStatus(description, slackMessages string) (string, error)
 	GenerateImpact(description, slackMessages string) (string, error)
+	GenerateOccurredAt(description, slackMessages, defaultTime string) (string, error)
 	GenerateRootCause(description, slackMessages string) (string, error)
 	GenerateTrigger(description, slackMessages string) (string, error)
 	GenerateSolution(description, slackMessages string) (string, error)
@@ -312,7 +313,7 @@ func (h *AIRepository) processMultipleChunks(basePrompt string, messages []slack
 func (h *AIRepository) formatMessagesSimple(messages []slack.Message) string {
 	var builder strings.Builder
 	for _, msg := range messages {
-		builder.WriteString(fmt.Sprintf("%s: %s\n", msg.User, msg.Text))
+		fmt.Fprintf(&builder, "%s: %s\n", msg.User, msg.Text)
 	}
 	return builder.String()
 }
@@ -774,8 +775,33 @@ func (h *AIRepository) mergePostMortemSummaries(summaries []string) (string, err
 `)
 
 	for i, summary := range summaries {
-		builder.WriteString(fmt.Sprintf("## 部分要約 %d\n%s\n\n", i+1, summary))
+		fmt.Fprintf(&builder, "## 部分要約 %d\n%s\n\n", i+1, summary)
 	}
 
 	return h.callOpenAIWithRetryWithErrorHandling(builder.String())
+}
+
+// GenerateOccurredAt は発生日時を推定する。
+// Slackメッセージ内に発生時刻の手がかりがあればそれを優先し、無ければdefaultTimeを返す
+func (h *AIRepository) GenerateOccurredAt(description, slackMessages, defaultTime string) (string, error) {
+	prompt := fmt.Sprintf(`## 依頼内容
+インシデントの発生日時を推定してください。
+あなたには、人間が考えた事象の概要、Slackのメッセージ、既定の発生日時（システム記録）が与えられます。
+
+## フォーマットの指定：
+- 「YYYY-MM-DD HH:MM」形式で発生日時のみを返してください。
+- Slackメッセージ内に発生時刻を示す情報があればそれを優先してください。
+- 手がかりが無い場合は、与えられた既定の発生日時をそのまま返してください。
+- 余計な説明やラベルは付けず、日時の文字列だけを返してください。
+
+## 既定の発生日時
+%s
+
+## 人間が考えた事象の概要
+%s
+
+## 関連するSlackのメッセージ
+%s`, defaultTime, description, slackMessages)
+
+	return h.callOpenAIWithRetry(prompt)
 }

--- a/domain/repository/config_announce_test.go
+++ b/domain/repository/config_announce_test.go
@@ -1,0 +1,18 @@
+package repository
+
+import "testing"
+
+func TestIsManualGlobalAnnouncement(t *testing.T) {
+	if !(&Config{ManualGlobalAnnouncement: true}).IsManualGlobalAnnouncement() {
+		t.Fatal("true を設定したら true を返すべき")
+	}
+	if (&Config{ManualGlobalAnnouncement: false}).IsManualGlobalAnnouncement() {
+		t.Fatal("false を設定したら false を返すべき")
+	}
+
+	// nil レシーバでも panic せず false を返す（テストで nil Config が渡るため）
+	var c *Config
+	if c.IsManualGlobalAnnouncement() {
+		t.Fatal("nil Config は false を返すべき")
+	}
+}

--- a/domain/repository/config_repository.go
+++ b/domain/repository/config_repository.go
@@ -42,6 +42,7 @@ type Config struct {
 	IncidentLevelList          []entity.IncidentLevel  `mapstructure:"incident_levels" validate:"required"`
 	DefaultConfluence          entity.ConfluenceConfig `mapstructure:"default_confluence"`
 	NotificationType           string                  `mapstructure:"notification_type" validate:"omitempty,oneof=none here channel"`
+	ManualGlobalAnnouncement   bool                    `mapstructure:"manual_global_announcement"`
 }
 
 func (c *Config) Services(_ context.Context) ([]entity.Service, error) {
@@ -102,4 +103,13 @@ func (c *Config) GetNotificationType() string {
 		return "here"
 	}
 	return c.NotificationType
+}
+
+// IsManualGlobalAnnouncement は global_announcement_channels への通知を
+// 手動（インシデントチャンネルのメニュー操作時のみ）にするかどうかを返す
+func (c *Config) IsManualGlobalAnnouncement() bool {
+	if c == nil {
+		return false
+	}
+	return c.ManualGlobalAnnouncement
 }

--- a/domain/repository/slack_repository.go
+++ b/domain/repository/slack_repository.go
@@ -25,6 +25,7 @@ type SlackRepositoryer interface {
 	UpdateMessage(channelID, ts string, opts ...slack.MsgOption)
 	DeleteMessage(channelID, ts string)
 	OpenView(triggerID string, view slack.ModalViewRequest) error
+	UpdateView(externalID string, view slack.ModalViewRequest) error
 	CreateConversation(params slack.CreateConversationParams) (*slack.Channel, error)
 	SetTopicOfConversation(channelID, topic string) error
 	InviteUsersToConversation(channelID string, users ...string) error
@@ -335,6 +336,13 @@ func (h *SlackRepository) GetMemberIDs(name string) ([]string, error) {
 		}
 	}
 	return nil, ErrSlackNotFound
+}
+
+func (h *SlackRepository) UpdateView(externalID string, view slack.ModalViewRequest) error {
+	return retry.Retry(3, 500*time.Millisecond, func() error {
+		_, err := h.client.UpdateView(view, externalID, "", "")
+		return err
+	})
 }
 
 func (h *SlackRepository) OpenView(triggerID string, view slack.ModalViewRequest) error {

--- a/domain/repository/token_utils.go
+++ b/domain/repository/token_utils.go
@@ -181,7 +181,7 @@ func (tc *TokenCalculator) CreateMergePrompt(summaries []string) string {
 	builder.WriteString("以下は複数の部分的なインシデント進捗サマリです。これらを統合して一つの完全なサマリを作成してください：\n\n")
 
 	for i, summary := range summaries {
-		builder.WriteString(fmt.Sprintf("## 部分サマリ %d\n%s\n\n", i+1, summary))
+		fmt.Fprintf(&builder, "## 部分サマリ %d\n%s\n\n", i+1, summary)
 	}
 
 	builder.WriteString("これらの情報を統合し、重複を排除して、以下の構成で最終サマリを作成してください：\n")

--- a/example/yas3.toml
+++ b/example/yas3.toml
@@ -1,5 +1,9 @@
 global_announcement_channels = ["all-pyama-dev"]
 
+# trueにするとglobal_announcement_channelsへの自動通知を止め、
+# インシデントチャンネルのメニュー操作時のみ手動で周知します（入力モーダルでAIが下書きを生成）
+manual_global_announcement = true
+
 [default_confluence]
 domain = "example"
 space = "YAS3"

--- a/handler/callback.go
+++ b/handler/callback.go
@@ -216,6 +216,11 @@ func (h *CallbackHandler) Handle(callback *slack.InteractionCallback) error {
 				if err := h.openEditSummaryModal(callback.TriggerID, callback.Channel.ID); err != nil {
 					return fmt.Errorf("openEditSummaryModal failed: %w", err)
 				}
+			case "announce_global":
+				slog.Info("announce_global", slog.Any("channelID", callback.Channel.ID))
+				if err := h.openGlobalAnnounceModal(callback.TriggerID, callback.Channel.ID); err != nil {
+					return fmt.Errorf("openGlobalAnnounceModal failed: %w", err)
+				}
 			case "create_postmortem":
 				slog.Info("create_postmortem", slog.Any("channelID", callback.Channel.ID))
 				if err := h.showPostMortemButton(callback.Channel.ID); err != nil {
@@ -290,6 +295,10 @@ func (h *CallbackHandler) Handle(callback *slack.InteractionCallback) error {
 		case "edit_summary_modal":
 			if err := h.submitEditSummaryModal(callback); err != nil {
 				return fmt.Errorf("submitEditSummaryModal failed: %w", err)
+			}
+		case "global_announce_modal":
+			if err := h.submitGlobalAnnounceModal(callback); err != nil {
+				return fmt.Errorf("submitGlobalAnnounceModal failed: %w", err)
 			}
 		case "link_incident_modal":
 			if err := h.submitLinkIncidentModal(callback); err != nil {
@@ -1059,8 +1068,8 @@ func (h *CallbackHandler) broadCastAnnouncement(channelID string, attachment sla
 		}
 	}
 
-	// グローバルアナウンスチャンネルを追加
-	if h.config != nil {
+	// グローバルアナウンスチャンネルを追加（手動通知モードの場合はスキップし、メニュー操作時のみ通知する）
+	if h.config != nil && !h.config.IsManualGlobalAnnouncement() {
 		for _, c := range h.config.GetGlobalAnnouncementChannels(h.ctx) {
 			announceChannels[c] = true
 		}
@@ -1457,7 +1466,7 @@ func (h *CallbackHandler) createProgressSummaryFallback(channel slack.Channel, i
 	// Slackメッセージを整形してタイムラインとして渡す
 	var timeline strings.Builder
 	for _, msg := range pinnedMessages {
-		timeline.WriteString(fmt.Sprintf("%s: %s\n", msg.User, msg.Text))
+		fmt.Fprintf(&timeline, "%s: %s\n", msg.User, msg.Text)
 	}
 
 	// AIで進捗サマリを生成（従来の方式）
@@ -1674,7 +1683,7 @@ func (h *CallbackHandler) createProgressSummaryFallbackWithUpdate(channel slack.
 	// Slackメッセージを整形してタイムラインとして渡す
 	var timeline strings.Builder
 	for _, msg := range pinnedMessages {
-		timeline.WriteString(fmt.Sprintf("%s: %s\n", msg.User, msg.Text))
+		fmt.Fprintf(&timeline, "%s: %s\n", msg.User, msg.Text)
 	}
 
 	// AIで進捗サマリを生成（従来の方式）
@@ -2199,7 +2208,7 @@ func (h *CallbackHandler) postIncidentDetail(channelID, threadTS string, inciden
 			// メッセージを整形
 			var formattedMessages strings.Builder
 			for _, msg := range messages {
-				formattedMessages.WriteString(fmt.Sprintf("%s: %s\n", msg.User, msg.Text))
+				fmt.Fprintf(&formattedMessages, "%s: %s\n", msg.User, msg.Text)
 			}
 
 			// AI で残件分析

--- a/handler/callback_test.go
+++ b/handler/callback_test.go
@@ -46,6 +46,10 @@ func (m *mockAIRepository) GenerateImpact(description, slackMessages string) (st
 	return "", nil
 }
 
+func (m *mockAIRepository) GenerateOccurredAt(description, slackMessages, defaultTime string) (string, error) {
+	return "", nil
+}
+
 func (m *mockAIRepository) GenerateRootCause(description, slackMessages string) (string, error) {
 	return "", nil
 }

--- a/handler/event.go
+++ b/handler/event.go
@@ -102,7 +102,7 @@ func (h *EventHandler) handleMetionEvent(event *slackevents.AppMentionEvent) err
 		}
 	} else {
 		msgOptions := []slack.MsgOption{
-			slack.MsgOptionBlocks(blocks.IncidentMenu()...),
+			slack.MsgOptionBlocks(blocks.IncidentMenu(h.config.IsManualGlobalAnnouncement())...),
 		}
 		if event.ThreadTimeStamp != "" {
 			msgOptions = append(msgOptions, slack.MsgOptionTS(event.ThreadTimeStamp))

--- a/handler/global_announcement.go
+++ b/handler/global_announcement.go
@@ -1,0 +1,181 @@
+package handler
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/pyama86/YAS3/domain/entity"
+	"github.com/pyama86/YAS3/presentation/blocks"
+	"github.com/slack-go/slack"
+)
+
+const globalAnnounceModalCallbackID = "global_announce_modal"
+
+// openGlobalAnnounceModal は障害報告の入力モーダルを開く。
+// trigger_idは3秒で失効するため、まずローディングモーダルを即時に開き、
+// 裏でAIが下書きを生成してから views.update でフォームに差し替える。
+func (h *CallbackHandler) openGlobalAnnounceModal(triggerID, channelID string) error {
+	incident, err := h.repository.FindIncidentByChannel(h.ctx, channelID)
+	if err != nil {
+		return fmt.Errorf("failed to FindIncidentByChannel: %w", err)
+	}
+	if incident == nil {
+		return fmt.Errorf("incident is nil")
+	}
+
+	externalID := fmt.Sprintf("global_announce_%s", channelID)
+
+	loading := slack.ModalViewRequest{
+		Type:            slack.ViewType("modal"),
+		Title:           slack.NewTextBlockObject("plain_text", "📢 障害報告", false, false),
+		Close:           slack.NewTextBlockObject("plain_text", "❌ キャンセル", false, false),
+		Blocks:          blocks.GlobalAnnounceLoading(),
+		PrivateMetadata: channelID,
+		ExternalID:      externalID,
+		CallbackID:      globalAnnounceModalCallbackID,
+	}
+	if err := h.repository.OpenView(triggerID, loading); err != nil {
+		return fmt.Errorf("failed to OpenView: %w", err)
+	}
+
+	// AI生成は時間がかかるため非同期で実行し、完了後にviews.updateで差し替える
+	go h.updateGlobalAnnounceModalWithDraft(channelID, externalID, incident)
+
+	return nil
+}
+
+// updateGlobalAnnounceModalWithDraft はAIで下書きを生成し、views.updateでフォームに差し替える
+func (h *CallbackHandler) updateGlobalAnnounceModalWithDraft(channelID, externalID string, incident *entity.Incident) {
+	summary, occurredAt, impact := h.buildAnnounceDraft(channelID, incident)
+
+	view := slack.ModalViewRequest{
+		Type:            slack.ViewType("modal"),
+		Title:           slack.NewTextBlockObject("plain_text", "📢 障害報告", false, false),
+		Submit:          slack.NewTextBlockObject("plain_text", "✅ 報告する", false, false),
+		Close:           slack.NewTextBlockObject("plain_text", "❌ キャンセル", false, false),
+		Blocks:          blocks.GlobalAnnounceForm(summary, occurredAt, impact),
+		PrivateMetadata: channelID,
+		ExternalID:      externalID,
+		CallbackID:      globalAnnounceModalCallbackID,
+	}
+	if err := h.repository.UpdateView(externalID, view); err != nil {
+		slog.Error("Failed to UpdateView for global announce", slog.Any("err", err))
+	}
+}
+
+// buildAnnounceDraft はAIで発生事象・発生日時・影響範囲の下書きを生成する。
+// AIが未設定/失敗時はインシデント情報からのフォールバック値を返す。
+func (h *CallbackHandler) buildAnnounceDraft(channelID string, incident *entity.Incident) (summary, occurredAt, impact string) {
+	summary = incident.Description
+	occurredAt = incident.StartedAt.Format("2006-01-02 15:04")
+	impact = ""
+
+	if h.aiRepository == nil {
+		return summary, occurredAt, impact
+	}
+
+	messages, err := h.collectChannelMessages(channelID, incident)
+	if err != nil {
+		slog.Error("Failed to collectChannelMessages for announce draft", slog.Any("err", err))
+		return summary, occurredAt, impact
+	}
+
+	var b strings.Builder
+	for _, m := range messages {
+		fmt.Fprintf(&b, "%s: %s\n", m.User, m.Text)
+	}
+	formatted := b.String()
+
+	if s, err := h.aiRepository.Summarize(incident.Description, formatted); err == nil && strings.TrimSpace(s) != "" {
+		summary = s
+	}
+	if oc, err := h.aiRepository.GenerateOccurredAt(incident.Description, formatted, occurredAt); err == nil && strings.TrimSpace(oc) != "" {
+		occurredAt = oc
+	}
+	if im, err := h.aiRepository.GenerateImpact(incident.Description, formatted); err == nil && strings.TrimSpace(im) != "" {
+		impact = im
+	}
+
+	return summary, occurredAt, impact
+}
+
+// submitGlobalAnnounceModal はフォーム送信を受けて global_announcement_channels のみに周知する
+func (h *CallbackHandler) submitGlobalAnnounceModal(callback *slack.InteractionCallback) error {
+	channelID := callback.View.PrivateMetadata
+	summary := callback.View.State.Values["summary_block"]["summary_text"].Value
+	occurredAt := callback.View.State.Values["occurred_block"]["occurred_text"].Value
+	impact := callback.View.State.Values["impact_block"]["impact_text"].Value
+	userID := callback.User.ID
+
+	incident, err := h.repository.FindIncidentByChannel(h.ctx, channelID)
+	if err != nil {
+		return fmt.Errorf("failed to FindIncidentByChannel: %w", err)
+	}
+	if incident == nil {
+		return fmt.Errorf("incident is nil")
+	}
+
+	service, err := h.repository.ServiceByID(h.ctx, incident.ServiceID)
+	if err != nil {
+		return fmt.Errorf("failed to ServiceByID: %w", err)
+	}
+
+	attachment := slack.Attachment{
+		Color:  urgencyColorMap[incident.Urgency],
+		Blocks: slack.Blocks{BlockSet: blocks.GlobalAnnouncement(summary, occurredAt, impact, channelID, service)},
+	}
+
+	return h.announceToGlobalChannels(channelID, userID, attachment)
+}
+
+// announceToGlobalChannels は global_announcement_channels のみに通知する（手動周知用）。
+// サービス固有のアナウンスチャンネルはインシデント作成時に自動通知済みのため対象外とする。
+func (h *CallbackHandler) announceToGlobalChannels(channelID, userID string, attachment slack.Attachment) error {
+	if h.config == nil {
+		return nil
+	}
+
+	channels := h.config.GetGlobalAnnouncementChannels(h.ctx)
+	if len(channels) == 0 {
+		if _, _, err := h.repository.PostMessage(
+			channelID,
+			slack.MsgOptionText("⚠️ global_announcement_channels が設定されていません", false),
+		); err != nil {
+			slog.Error("Failed to post no global channels message", slog.Any("err", err))
+		}
+		return nil
+	}
+
+	notificationType := h.config.GetNotificationType()
+	posted := make(map[string]bool)
+	for _, c := range channels {
+		cinfo, err := h.repository.GetChannelByName(c)
+		if err != nil || cinfo == nil {
+			slog.Error("failed to GetChannelByName", slog.Any("channel", c), slog.Any("err", err))
+			continue
+		}
+		if posted[cinfo.ID] {
+			continue
+		}
+
+		var msgOptions []slack.MsgOption
+		if notificationText := blocks.AddNotification("", notificationType); notificationText != "" {
+			msgOptions = append(msgOptions, slack.MsgOptionText(notificationText, false))
+		}
+		msgOptions = append(msgOptions, slack.MsgOptionAttachments(attachment))
+
+		if _, _, err := h.repository.PostMessage(cinfo.ID, msgOptions...); err != nil {
+			return fmt.Errorf("failed to post announcement to channel %s: %w", cinfo.Name, err)
+		}
+		posted[cinfo.ID] = true
+
+		if _, _, err := h.repository.PostMessage(
+			channelID,
+			slack.MsgOptionText(fmt.Sprintf("📢 <@%s> が %s チャンネルに障害報告しました", userID, cinfo.Name), false),
+		); err != nil {
+			slog.Error("Failed to post notification message", slog.Any("err", err))
+		}
+	}
+	return nil
+}

--- a/handler/global_announcement_test.go
+++ b/handler/global_announcement_test.go
@@ -1,0 +1,93 @@
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slacktest"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pyama86/YAS3/domain/entity"
+	"github.com/pyama86/YAS3/domain/repository"
+	"github.com/pyama86/YAS3/handler"
+)
+
+// 全体周知モーダルの送信で、global_announcement_channels のみに周知されることを検証する
+func TestGlobalAnnounceSubmit(t *testing.T) {
+	var postMsg []map[string]string
+	srv := slacktest.NewTestServer(func(c slacktest.Customize) {
+		c.Handle("/chat.postMessage", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = r.ParseForm()
+			postMsg = append(postMsg, map[string]string{
+				"channel":     r.FormValue("channel"),
+				"attachments": r.FormValue("attachments"),
+				"text":        r.FormValue("text"),
+			})
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		}))
+		c.Handle("/conversations.list", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			resp := map[string]any{
+				"ok": true,
+				"channels": []map[string]any{
+					{"id": "CANN", "name": "ann", "is_archived": false},
+					{"id": "CINC", "name": "inc", "is_archived": false},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+		}))
+	})
+	go srv.Start()
+	defer srv.Stop()
+
+	api := slack.New("dummy", slack.OptionAPIURL(srv.GetAPIURL()))
+	incRepo := &mockIncidentRepo{data: map[string]*entity.Incident{
+		"CINC": {
+			ChannelID:   "CINC",
+			ServiceID:   1,
+			Urgency:     "error",
+			Description: "事象内容",
+			StartedAt:   time.Date(2026, 6, 9, 14, 30, 0, 0, time.UTC),
+		},
+	}}
+	cfgRepo := &mockConfigRepo{services: []entity.Service{{ID: 1, Name: "svc"}}}
+	repo := repository.NewRepository(incRepo, cfgRepo, cfgRepo, repository.NewSlackRepository(api))
+	// global_announcement_channels に "ann" を設定（手動周知の対象）
+	config := &repository.Config{
+		GlobalAnnouncementChannels: []string{"ann"},
+		NotificationType:           "none",
+	}
+	cbHandler := handler.NewCallbackHandler(context.Background(), repo, "https://example.com/", nil, nil, config)
+
+	cb := slack.InteractionCallback{
+		Type: slack.InteractionTypeViewSubmission,
+		View: slack.View{
+			CallbackID:      "global_announce_modal",
+			PrivateMetadata: "CINC",
+			State: &slack.ViewState{
+				Values: map[string]map[string]slack.BlockAction{
+					"summary_block":  {"summary_text": {Value: "発生事象です"}},
+					"occurred_block": {"occurred_text": {Value: "2026-06-09 14:30"}},
+					"impact_block":   {"impact_text": {Value: "影響あり"}},
+				},
+			},
+		},
+		User: slack.User{ID: "U1"},
+	}
+
+	err := cbHandler.Handle(&cb)
+	assert.NoError(t, err)
+
+	postedToGlobal := false
+	for _, p := range postMsg {
+		if p["channel"] == "CANN" && p["attachments"] != "" {
+			postedToGlobal = true
+		}
+	}
+	assert.True(t, postedToGlobal, "global チャンネル(CANN)に周知が投稿されるべき: %+v", postMsg)
+}

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -104,7 +104,7 @@ func Handle(ctx context.Context, configPath string) error {
 					// StartedAtから15分間隔で判定
 					elapsed := now.Sub(incident.StartedAt)
 					if int(elapsed.Minutes())%15 == 0 && int(elapsed.Seconds())%60 < 60 {
-						if err := timeKeeperMessage(webApi, &incident, slackRepository); err != nil {
+						if err := timeKeeperMessage(webApi, &incident, slackRepository, cfgRepository.IsManualGlobalAnnouncement()); err != nil {
 							slog.Error("Failed to send time keeper message", slog.Any("err", err))
 						}
 					}
@@ -148,7 +148,7 @@ func Handle(ctx context.Context, configPath string) error {
 	return socketMode.Run()
 }
 
-func timeKeeperMessage(client *slack.Client, incident *entity.Incident, slackRepository *repository.SlackRepository) error {
+func timeKeeperMessage(client *slack.Client, incident *entity.Incident, slackRepository *repository.SlackRepository, manualGlobalAnnounce bool) error {
 	channelID := incident.ChannelID
 	channel, err := slackRepository.GetChannelByID(channelID)
 	if err != nil {
@@ -169,7 +169,7 @@ func timeKeeperMessage(client *slack.Client, incident *entity.Incident, slackRep
 	// 15分ごとのチェックポイントの案内
 	_, _, err = client.PostMessage(
 		channelID,
-		slack.MsgOptionBlocks(blocks.CheckPoint(elapsedStr)...),
+		slack.MsgOptionBlocks(blocks.CheckPoint(elapsedStr, manualGlobalAnnounce)...),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to post time keeper message %s: %w", channel.Name, err)

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -83,6 +83,10 @@ func (m *mockSlackRepo) UpdateMessage(channelID, timestamp string, options ...sl
 
 func (m *mockSlackRepo) DeleteMessage(channelID, timestamp string) {}
 
+func (m *mockSlackRepo) UpdateView(externalID string, view slack.ModalViewRequest) error {
+	return nil
+}
+
 func (m *mockSlackRepo) OpenView(triggerID string, view slack.ModalViewRequest) error {
 	return nil
 }

--- a/presentation/blocks/check_point.go
+++ b/presentation/blocks/check_point.go
@@ -6,7 +6,7 @@ import (
 	"github.com/slack-go/slack"
 )
 
-func CheckPoint(elapsedStr string) []slack.Block {
+func CheckPoint(elapsedStr string, manualGlobalAnnounce bool) []slack.Block {
 	blocks := []slack.Block{}
 
 	// 0時間0分の場合はチェックポイントメッセージを表示しない
@@ -41,7 +41,7 @@ func CheckPoint(elapsedStr string) []slack.Block {
 				slack.OptTypeStatic,
 				slack.NewTextBlockObject("plain_text", "操作を選択してください", false, false),
 				"in_channel_options",
-				InChannelOptions()...,
+				InChannelOptions(manualGlobalAnnounce)...,
 			),
 			slack.NewButtonBlockElement(
 				"progress_summary_action",

--- a/presentation/blocks/global_announcement.go
+++ b/presentation/blocks/global_announcement.go
@@ -1,0 +1,118 @@
+package blocks
+
+import (
+	"fmt"
+
+	"github.com/pyama86/YAS3/domain/entity"
+	"github.com/slack-go/slack"
+)
+
+// GlobalAnnounceLoading はAIが下書きを生成している間に表示するローディングモーダルのブロック
+func GlobalAnnounceLoading() slack.Blocks {
+	return slack.Blocks{
+		BlockSet: []slack.Block{
+			slack.NewSectionBlock(
+				slack.NewTextBlockObject(
+					"mrkdwn",
+					":hourglass_flowing_sand: AIが障害報告の下書きを作成しています…\nしばらくお待ちください。",
+					false,
+					false,
+				),
+				nil,
+				nil,
+			),
+		},
+	}
+}
+
+// GlobalAnnounceForm は障害報告の入力フォーム。AIが生成した下書きを初期値として埋める
+// 各入力には文字数上限を設定し、通知時の文字数制限超過を防ぐ
+func GlobalAnnounceForm(summary, occurredAt, impact string) slack.Blocks {
+	return slack.Blocks{
+		BlockSet: []slack.Block{
+			&slack.InputBlock{
+				Type:    slack.MBTInput,
+				BlockID: "summary_block",
+				Label:   slack.NewTextBlockObject("plain_text", "発生事象", false, false),
+				Element: &slack.PlainTextInputBlockElement{
+					Type:         slack.METPlainTextInput,
+					ActionID:     "summary_text",
+					InitialValue: summary,
+					Multiline:    true,
+					MaxLength:    2000,
+					Placeholder:  slack.NewTextBlockObject("plain_text", "例: ◯◯機能でエラーが発生しています", false, false),
+				},
+				Optional: false,
+			},
+			&slack.InputBlock{
+				Type:    slack.MBTInput,
+				BlockID: "occurred_block",
+				Label:   slack.NewTextBlockObject("plain_text", "発生日時", false, false),
+				Element: &slack.PlainTextInputBlockElement{
+					Type:         slack.METPlainTextInput,
+					ActionID:     "occurred_text",
+					InitialValue: occurredAt,
+					MaxLength:    100,
+					Placeholder:  slack.NewTextBlockObject("plain_text", "例: 2026-06-09 14:30 頃", false, false),
+				},
+				Optional: false,
+			},
+			&slack.InputBlock{
+				Type:    slack.MBTInput,
+				BlockID: "impact_block",
+				Label:   slack.NewTextBlockObject("plain_text", "影響範囲", false, false),
+				Element: &slack.PlainTextInputBlockElement{
+					Type:         slack.METPlainTextInput,
+					ActionID:     "impact_text",
+					InitialValue: impact,
+					Multiline:    true,
+					MaxLength:    2000,
+					Placeholder:  slack.NewTextBlockObject("plain_text", "例: 一部ユーザーがログインできません", false, false),
+				},
+				Optional: true,
+			},
+		},
+	}
+}
+
+// GlobalAnnouncement は障害報告メッセージ（attachment内）のブロックを組み立てる
+func GlobalAnnouncement(summary, occurredAt, impact, channelID string, service *entity.Service) []slack.Block {
+	fields := []*slack.TextBlockObject{
+		slack.NewTextBlockObject("mrkdwn", fmt.Sprintf("*発生日時:* %s", truncateRunes(occurredAt, 300)), false, false),
+		slack.NewTextBlockObject("mrkdwn", fmt.Sprintf("*対応チャンネル:* <#%s>", channelID), false, false),
+	}
+	if service != nil {
+		fields = append(fields, slack.NewTextBlockObject("mrkdwn", fmt.Sprintf("*サービス:* %s", service.Name), false, false))
+	}
+
+	blockSet := []slack.Block{
+		slack.NewSectionBlock(
+			slack.NewTextBlockObject("mrkdwn", ":rotating_light: *障害報告*", false, false),
+			nil,
+			nil,
+		),
+		slack.NewSectionBlock(
+			slack.NewTextBlockObject("mrkdwn", fmt.Sprintf("*発生事象:*\n%s", truncateRunes(summary, 2800)), false, false),
+			nil,
+			nil,
+		),
+		slack.NewSectionBlock(nil, fields, nil),
+	}
+	if impact != "" {
+		blockSet = append(blockSet, slack.NewSectionBlock(
+			slack.NewTextBlockObject("mrkdwn", fmt.Sprintf("*影響範囲:*\n%s", truncateRunes(impact, 2800)), false, false),
+			nil,
+			nil,
+		))
+	}
+	return blockSet
+}
+
+// truncateRunes はSlackのmrkdwnセクション上限(3000文字)に収まるようルーン単位で切り詰める
+func truncateRunes(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max-1]) + "…"
+}

--- a/presentation/blocks/global_announcement_test.go
+++ b/presentation/blocks/global_announcement_test.go
@@ -1,0 +1,112 @@
+package blocks
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pyama86/YAS3/domain/entity"
+	"github.com/slack-go/slack"
+)
+
+func TestInChannelOptions_ManualToggle(t *testing.T) {
+	off := InChannelOptions(false)
+	for _, o := range off {
+		if o.Value == "announce_global" {
+			t.Fatalf("announce_global は無効時に含めてはいけない")
+		}
+	}
+
+	on := InChannelOptions(true)
+	found := false
+	for _, o := range on {
+		if o.Value == "announce_global" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("announce_global は有効時に含めるべき")
+	}
+	if len(on) != len(off)+1 {
+		t.Fatalf("有効時はオプションが1つ多いはず: off=%d on=%d", len(off), len(on))
+	}
+}
+
+func TestGlobalAnnounceForm(t *testing.T) {
+	b := GlobalAnnounceForm("初期事象", "2026-06-09 14:30", "初期影響")
+	if len(b.BlockSet) != 3 {
+		t.Fatalf("入力ブロックは3つのはず: got %d", len(b.BlockSet))
+	}
+
+	wantIDs := []string{"summary_block", "occurred_block", "impact_block"}
+	for i, blk := range b.BlockSet {
+		ib, ok := blk.(*slack.InputBlock)
+		if !ok {
+			t.Fatalf("block %d は InputBlock ではない", i)
+		}
+		if ib.BlockID != wantIDs[i] {
+			t.Fatalf("block %d の BlockID = %s, want %s", i, ib.BlockID, wantIDs[i])
+		}
+		el, ok := ib.Element.(*slack.PlainTextInputBlockElement)
+		if !ok {
+			t.Fatalf("block %d の Element が PlainTextInput ではない", i)
+		}
+		// 文字数制限が設定されていること
+		if el.MaxLength <= 0 {
+			t.Fatalf("block %d に MaxLength が未設定", i)
+		}
+	}
+
+	// AIが生成した初期値が埋め込まれていること
+	summary := b.BlockSet[0].(*slack.InputBlock).Element.(*slack.PlainTextInputBlockElement)
+	if summary.InitialValue != "初期事象" {
+		t.Fatalf("発生事象の初期値が反映されていない: %q", summary.InitialValue)
+	}
+}
+
+func TestGlobalAnnouncement_ImpactOmitted(t *testing.T) {
+	svc := &entity.Service{ID: 1, Name: "svc"}
+
+	withImpact := GlobalAnnouncement("概要", "2026-06-09 14:30", "影響あり", "C1", svc)
+	if !containsSectionText(withImpact, "影響範囲") {
+		t.Fatalf("影響範囲があるときは影響範囲セクションを含めるべき")
+	}
+
+	without := GlobalAnnouncement("概要", "2026-06-09 14:30", "", "C1", svc)
+	if containsSectionText(without, "影響範囲") {
+		t.Fatalf("影響範囲が空のときは影響範囲セクションを省くべき")
+	}
+	if !containsSectionText(without, "概要") {
+		t.Fatalf("発生事象は常に含めるべき")
+	}
+}
+
+func TestTruncateRunes(t *testing.T) {
+	if got := truncateRunes("hello", 10); got != "hello" {
+		t.Fatalf("上限以内の文字列は変更しない: got %q", got)
+	}
+	got := truncateRunes("あいうえお", 3)
+	if r := []rune(got); len(r) != 3 {
+		t.Fatalf("3ルーンに収めるべき: got %d (%q)", len(r), got)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("省略記号で終わるべき: got %q", got)
+	}
+}
+
+func containsSectionText(blocks []slack.Block, sub string) bool {
+	for _, b := range blocks {
+		sec, ok := b.(*slack.SectionBlock)
+		if !ok {
+			continue
+		}
+		if sec.Text != nil && strings.Contains(sec.Text.Text, sub) {
+			return true
+		}
+		for _, f := range sec.Fields {
+			if strings.Contains(f.Text, sub) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/presentation/blocks/inchannel_options.go
+++ b/presentation/blocks/inchannel_options.go
@@ -2,8 +2,8 @@ package blocks
 
 import "github.com/slack-go/slack"
 
-func InChannelOptions() []*slack.OptionBlockObject {
-	return []*slack.OptionBlockObject{
+func InChannelOptions(manualGlobalAnnounce bool) []*slack.OptionBlockObject {
+	options := []*slack.OptionBlockObject{
 		slack.NewOptionBlockObject(
 			"set_incident_level",
 			slack.NewTextBlockObject("plain_text", "⚙️ 事象レベルをセットする", false, false),
@@ -40,4 +40,12 @@ func InChannelOptions() []*slack.OptionBlockObject {
 			nil,
 		),
 	}
+	if manualGlobalAnnounce {
+		options = append(options, slack.NewOptionBlockObject(
+			"announce_global",
+			slack.NewTextBlockObject("plain_text", "📢 障害報告を送る", false, false),
+			nil,
+		))
+	}
+	return options
 }

--- a/presentation/blocks/incident_menu.go
+++ b/presentation/blocks/incident_menu.go
@@ -4,7 +4,7 @@ import (
 	"github.com/slack-go/slack"
 )
 
-func IncidentMenu() []slack.Block {
+func IncidentMenu(manualGlobalAnnounce bool) []slack.Block {
 	return []slack.Block{
 		slack.NewSectionBlock(
 			slack.NewTextBlockObject(
@@ -21,7 +21,7 @@ func IncidentMenu() []slack.Block {
 				slack.OptTypeStatic,
 				slack.NewTextBlockObject("plain_text", "操作を選択してください", false, false),
 				"in_channel_options",
-				InChannelOptions()...,
+				InChannelOptions(manualGlobalAnnounce)...,
 			),
 			slack.NewButtonBlockElement(
 				"cancel_action",


### PR DESCRIPTION
## Summary
- `manual_global_announcement` (bool, 既定 false) を追加。`true` のとき `global_announcement_channels` への**自動通知を停止**し、インシデントチャンネルのメニューから**手動で障害報告**できるようにする
- メニューの「📢 障害報告を送る」を選ぶと、まずローディングモーダルを即時表示（trigger_id の3秒制限対策）→ 裏で AI が **発生事象 / 発生日時 / 影響範囲** の下書きを生成 → `views.update` で初期値入りフォームに差し替え → OK で `global_announcement_channels` に投稿
- 発生日時は `incident.StartedAt` を既定値とし、チャンネル内に発生時刻の手がかりがあれば AI がそちらを優先（`AIRepositorier.GenerateOccurredAt` を追加）
- Slack 文字数制限対策として入力 `MaxLength` を設定、通知本文はルーン単位で truncate

## 主要な変更
- 設定: `domain/repository/config_repository.go` に `ManualGlobalAnnouncement` と `IsManualGlobalAnnouncement()`（nil-safe）
- 通知: `handler/callback.go::broadCastAnnouncement` で `manual_global_announcement=true` のとき global チャンネルへの自動付与をスキップ
- メニュー: `InChannelOptions` / `IncidentMenu` / `CheckPoint` に `manualGlobalAnnounce bool` 引数を追加し、`true` のときだけ「📢 障害報告を送る」を表示
- ハンドラ: `handler/global_announcement.go` を新規追加（`openGlobalAnnounceModal` / `updateGlobalAnnounceModalWithDraft` / `buildAnnounceDraft` / `submitGlobalAnnounceModal` / `announceToGlobalChannels`）
- リポジトリ: `SlackRepositoryer.UpdateView` を追加（external_id 方式の `views.update`）
- AI: `AIRepositorier.GenerateOccurredAt(description, slackMessages, defaultTime)` を追加
- ブロック: `presentation/blocks/global_announcement.go` を新規追加（ローディング/フォーム/通知本文）
- ドキュメント: `doc/slack_app_manifest.yml`（Socket Mode 用マニフェスト）を追加
- 既存 `WriteString(fmt.Sprintf(...))` を `fmt.Fprintf` に置換（staticcheck QF1012 解消、等価変換）

## Test plan
- [x] `go build ./...`
- [x] `golangci-lint run ./...` → 0 issues
- [x] `go test ./...` → repository / handler / blocks 全 ok
- [x] `gofmt -l` → 差分なし
- [ ] 実機: `manual_global_announcement = true` に設定 → ボットメンション → 「📢 障害報告を送る」を選択 → モーダルが AI 初期値で開き、OK で global チャンネルに投稿されることを確認
- [ ] 実機: `manual_global_announcement = false`（既定）で従来通り自動通知されることを確認